### PR TITLE
Terry/Faraz/edits branch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,8 +40,14 @@ let redoMixin = {
       // console.log("Are these equal to each other?", action == this.undoneAction[this.undoneAction.length-1])
       if (!this.isTimetraveling) {
         if (this.undoneAction[this.undoneAction.length - 1]) {
-          if (action.type === this.undoneAction[this.undoneAction.length - 1].type &&
-            deepEqual(action.payload, this.undoneAction[this.undoneAction.length - 1].payload)) {
+          if (
+            action.type ===
+              this.undoneAction[this.undoneAction.length - 1].type &&
+            deepEqual(
+              action.payload,
+              this.undoneAction[this.undoneAction.length - 1].payload
+            )
+          ) {
             this.undoneAction.pop()
           } else {
             this.undoneAction = []
@@ -50,19 +56,21 @@ let redoMixin = {
       }
     })
   },
-
+  // undo + redo function calling
+  // metaKey accounts for Command Key on Mac
   mounted () {
     const throttledUndo = throttle(this.undo, 300)
     const throttledRedo = throttle(this.redo, 300)
-
+    // undo function calling
     window.addEventListener('keydown', event => {
-      if (event.ctrlKey && event.key === 'z') {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'z') {
         event.preventDefault()
         throttledUndo()
       }
     })
+    // redo function calling
     window.addEventListener('keydown', event => {
-      if (event.ctrlKey && event.key === 'y') {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'y') {
         event.preventDefault()
         throttledRedo()
       }
@@ -90,8 +98,10 @@ let redoMixin = {
         this.undoneAction.push(undone)
         if (ignoredActions.has(undone.type)) {
           // console.log('We undid an ignored action!')
-          while (this.doneAction[this.doneAction.length - 1] &&
-          ignoredActions.has(this.doneAction[this.doneAction.length - 1].type)) {
+          while (
+            this.doneAction[this.doneAction.length - 1] &&
+            ignoredActions.has(this.doneAction[this.doneAction.length - 1].type)
+          ) {
             this.undoneAction.push(this.doneAction.pop())
           }
           /* if we get here, that means we have undone all "useless" actions
@@ -130,7 +140,6 @@ let redoMixin = {
         this.redo()
       }
     }
-
   }
 }
 
@@ -140,5 +149,4 @@ export default {
 }
 </script>
 
-<style>
-</style>
+<style></style>

--- a/src/components/ComponentDisplay.vue
+++ b/src/components/ComponentDisplay.vue
@@ -382,10 +382,9 @@ export default {
   },
   watch: {
     activeComponent: function () {
-      if (this.activeComponent){
+      if (this.activeComponent) {
         this.onActivated(this.activeComponentObj)
-      }
-      else{
+      } else {
         this.onDeactivated()
       }
     }

--- a/test/jest/__tests__/App.spec.js
+++ b/test/jest/__tests__/App.spec.js
@@ -25,18 +25,18 @@ describe("Test mutations + actions to remove action from component and userActio
     };
   });
 
-  xit("deleting user action from state.userActions", () => {
+  it("deleting user action from state.userActions", () => {
     mutations.DELETE_USER_ACTIONS(state, "action");
     expect(state.userActions.length).toBe(0);
   });
 
-  xit('deleting "action" from componentMap', () => {
+  it('deleting "action" from componentMap', () => {
     mutations.REMOVE_ACTION_FROM_COMPONENT(state, "action");
     expect(state.componentMap.component.mapActions.length).toBe(0);
   });
 });
 
-xdescribe("Adding actions and state to components", () => {
+describe("Adding actions and state to components", () => {
   let state;
   beforeEach(() => {
     state = {
@@ -52,7 +52,7 @@ xdescribe("Adding actions and state to components", () => {
       activeComponent: "testComponent"
     };
   });
-  xdescribe("Adding actions to components", () => {
+  describe("Adding actions to components", () => {
     it("should add a single action to active component", () => {
       mutations.ADD_TO_COMPONENT_ACTIONS(state, "testAction");
       expect(
@@ -60,7 +60,7 @@ xdescribe("Adding actions and state to components", () => {
       ).toEqual(["testAction"]);
     });
   });
-  xdescribe("Adding state to components", () => {
+  describe("Adding state to components", () => {
     it("should add a single state string to active component", () => {
       mutations.ADD_TO_COMPONENT_STATE(state, "testState");
       expect(state.componentMap[state.activeComponent].componentState).toEqual([
@@ -70,7 +70,7 @@ xdescribe("Adding actions and state to components", () => {
   });
 });
 
-xdescribe("userActions mutation", () => {
+describe("userActions mutation", () => {
   let actions;
   let store;
   beforeEach(() => {
@@ -88,31 +88,31 @@ xdescribe("userActions mutation", () => {
   });
 });
 
-xdescribe("userStore mutation", () => {
+describe("userStore mutation", () => {
   let actions;
   let store;
   store = {
     userStore: {}
   };
-  xit("should be able to update store with a key defined by the user and a value of type object", () => {
+  it("should be able to update store with a key defined by the user and a value of type object", () => {
     mutations.ADD_TO_USER_STORE(store, { dummyKey: {} });
     // console.log('store.userStore.dummyKey', store.userStore.dummyKey);
     expect(store.userStore.dummyKey).toStrictEqual({});
   });
-  xit("should update user store with a key value pair with value strictly equal to empty array", () => {
+  it("should update user store with a key value pair with value strictly equal to empty array", () => {
     mutations.ADD_TO_USER_STORE(store, { dummyKey: [] });
     expect(store.userStore.dummyKey).toStrictEqual([]);
   });
-  xit("should be able to store booleans in the store as the key", () => {
+  it("should be able to store booleans in the store as the key", () => {
     mutations.ADD_TO_USER_STORE(store, { boolean: true });
     expect(store.userStore.boolean).toBe(true);
   });
-  xit("should add to userStore a key with a value of type number", () => {
+  it("should add to userStore a key with a value of type number", () => {
     mutations.ADD_TO_USER_STORE(store, { number: 696 });
     expect(store.userStore.number).toBe(696);
   });
 
-  xit("should work with strings too", () => {
+  it("should work with strings too", () => {
     mutations.ADD_TO_USER_STORE(store, { string: "string" });
     expect(store.userStore.string).toBe("string");
   });
@@ -126,7 +126,7 @@ xdescribe("userStore mutation", () => {
  *  `userStore` holds the user defined state objects
  */
 
-xdescribe("Delete state in userStore/componentMap", () => {
+describe("Delete state in userStore/componentMap", () => {
   let state;
   beforeEach(() => {
     state = {
@@ -143,13 +143,13 @@ xdescribe("Delete state in userStore/componentMap", () => {
       userStore: { state1: true, state2: [] }
     };
   });
-  xdescribe('"DELETE_USER_STATE" should delete property from "userStore" object', () => {
+  describe('"DELETE_USER_STATE" should delete property from "userStore" object', () => {
     it("should delete a single state property", () => {
       mutations.DELETE_USER_STATE(state, "state1");
       expect(state.userStore).toEqual({ state2: [] });
     });
   });
-  xdescribe('"REMOVE_STATE_FROM_COMPONENT" should delete state in "activeComponent"', () => {
+  describe('"REMOVE_STATE_FROM_COMPONENT" should delete state in "activeComponent"', () => {
     it("should remove state from active component", () => {
       mutations.REMOVE_STATE_FROM_COMPONENT(state, "state2");
       expect(state.componentMap.test.componentState).toEqual(["state1"]);


### PR DESCRIPTION
Updated undo/redo functionality to include Mac users the ability to undo + redo with 'Command + z' and 'Command + y' respectively 
Also enabled some disabled some tests to begin testing App functionality. Those updates will come in separate branch. 

Co-authored by Faraz Moallemi moallemifaraz@gmail.com 
Also Faraz assisted in this pull request so used Admin privileges to approve PR 