### PR TITLE
Keyla/debug drag transparency

### DIFF
--- a/src/components/left-sidebar/ComponentTab/CreateMenuHTMLQueue.vue
+++ b/src/components/left-sidebar/ComponentTab/CreateMenuHTMLQueue.vue
@@ -169,12 +169,13 @@ li {
   height: 35px;
   padding-top: 6px;
   text-align: center;
+  color: white;
   cursor: move;
 }
 
 .list-group-item-selected {
   display: inline-block;
-  margin: 4px 1.5%;
+  margin: 2px 1.5%;
   min-width: 175px;
   width: 30%;
   border-radius: 0.5cm;

--- a/src/components/right-sidebar/HTMLQueue.vue
+++ b/src/components/right-sidebar/HTMLQueue.vue
@@ -313,7 +313,7 @@ hr {
 }
 
 .currentlyDragging {
-  opacity: 1;
+  opacity: .5;
 }
 
 .ignoreByDragover {

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -26,7 +26,7 @@
 
 // **************** Taken from OverVue *******************
 $primary   : #737578;
-$secondary : #9c49a3;
+$secondary : #42B883;
 $accent    : #a1ddc2;
 $subaccent : #0d0d0d;
 $subaccentbtn : #2c384d;


### PR DESCRIPTION
Fixed the bug that prevented Html Elements in the HTMLQueue from turning transparent when they are dragged. I changed the secondary color from purple back to green.